### PR TITLE
Fix exception when requesting screen sharing in Chrome

### DIFF
--- a/html/janus.js
+++ b/html/janus.js
@@ -2042,7 +2042,7 @@ function Janus(gatewayCallbacks) {
 										]
 									}
 								};
-								constraints.video.mandatory.chromeMediaSourceId = event.data.sourceId;
+								constraints.video.mandatory.chromeMediaSourceId = sourceId;
 								getScreenMedia(constraints, callbackUserMedia, isAudioSendEnabled(media));
 							});
 						}


### PR DESCRIPTION
When using my custom screen-sharing add-on with the new extension API in Janus, trying to publish a screen-share would fail with an exception.